### PR TITLE
Set node version to 14 lts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
 
-      - name: Set up nodejs v12
+      - name: Set up nodejs v14
         uses: actions/setup-node@v1
         with:
-          node-version: '12'
+          node-version: '14'
 
       - name: Install dependencies
         run: npm install

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS builder
+FROM node:14-alpine AS builder
 WORKDIR /usr/src/node-builder
 COPY . .
 RUN npm install && \
@@ -8,7 +8,7 @@ RUN npm install && \
     mv ./tsconfig.json ./builder/tsconfig.json && \
     mv ./package.json ./builder/package.json
 
-FROM node:alpine
+FROM node:14-alpine
 WORKDIR /usr/src/project
 COPY --from=builder /usr/src/node-builder/builder .
 RUN npm install --production


### PR DESCRIPTION
This PR sets the node version for builds to node 14 lts. We should keep an eye on the node releases to always update onto the current lts version.